### PR TITLE
wait for draw signal to update libs after collection change

### DIFF
--- a/src/libs/lib.c
+++ b/src/libs/lib.c
@@ -810,10 +810,6 @@ void dt_lib_gui_set_expanded(dt_lib_module_t *module, gboolean expanded)
 
     if(dt_conf_get_bool("darkroom/ui/scroll_to_module"))
       darktable.gui->scroll_to[1] = module->expander;
-
-    /* announce that the module has been expanded */
-    if (DTGTK_IS_EXPANDER(module->expander) && module->on_expand)
-      module->on_expand(module);
   }
   else
   {

--- a/src/libs/lib_api.h
+++ b/src/libs/lib_api.h
@@ -66,9 +66,6 @@ OPTIONAL(void, view_enter, struct dt_lib_module_t *self, struct dt_view_t *old_v
 /** entering a view, only called if lib is displayed on the old view */
 OPTIONAL(void, view_leave, struct dt_lib_module_t *self, struct dt_view_t *old_view, struct dt_view_t *new_view);
 
-/** optional callback to be notified when the module is expanded */
-OPTIONAL(void, on_expand, struct dt_lib_module_t *self);
-
 /** optional event callbacks for big center widget. */
 /** optional method called after lighttable expose. */
 OPTIONAL(void, gui_post_expose, struct dt_lib_module_t *self, cairo_t *cr, int32_t width, int32_t height,

--- a/src/libs/tagging.c
+++ b/src/libs/tagging.c
@@ -152,6 +152,7 @@ static void _update_atdetach_buttons(dt_lib_module_t *self)
 {
   dt_lib_cancel_postponed_update(self);
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
+  d->display_is_stale = FALSE;
 
   const gboolean has_act_on = (dt_act_on_get_images_nb(FALSE, FALSE) > 0);
 
@@ -571,25 +572,17 @@ static void _collection_updated_callback(gpointer instance, dt_collection_change
 {
   dt_lib_tagging_t *d = (dt_lib_tagging_t *)self->data;
   d->collection[0] = '\0';
-  if(dt_lib_gui_get_expanded(self))
-  {
-    _update_atdetach_buttons(self);
-    d->display_is_stale = FALSE;
-  }
-  else
-  {
-    d->display_is_stale = TRUE;
-  }
+  d->display_is_stale = TRUE;
+  gtk_widget_queue_draw(self->widget);
 }
 
-void on_expand(dt_lib_module_t *self)
+static gboolean _draw_callback(GtkWidget *widget, gpointer cr, dt_lib_module_t *self)
 {
   dt_lib_tagging_t *const d = (dt_lib_tagging_t*)self->data;
   if(d->display_is_stale)
-  {
     _update_atdetach_buttons(self);
-    d->display_is_stale = FALSE;
-  }
+
+  return FALSE;
 }
 
 static void _raise_signal_tag_changed(dt_lib_module_t *self)
@@ -3146,6 +3139,8 @@ void gui_init(dt_lib_module_t *self)
   _set_keyword(self);
   _init_treeview(self, 1);
   _update_atdetach_buttons(self);
+
+  g_signal_connect(G_OBJECT(self->widget), "draw", G_CALLBACK(_draw_callback), self);
 }
 
 void gui_cleanup(dt_lib_module_t *self)


### PR DESCRIPTION
This has the advantage that modules hidden because their whole panel is hidden do not update their widgets after a collection change. Possibly modules that have scrolled out of view do not get updated either.