### PR TITLE
block input for long operations

### DIFF
--- a/src/gui/accelerators.c
+++ b/src/gui/accelerators.c
@@ -3894,6 +3894,15 @@ static float _process_shortcut(float move_size)
             "  [_process_shortcut] processing shortcut: %s\n",
             _shortcut_description(&_sc));
 
+  if(DT_PERFORM_ACTION(move_size) &&
+     gtk_widget_has_grab(darktable.control->progress_system.proxy.module->widget))
+  {
+    if(_sc.key_device == DT_SHORTCUT_DEVICE_KEYBOARD_MOUSE && _sc.key == GDK_KEY_Escape)
+      dt_print(DT_DEBUG_ALWAYS, "this should cancel the running blocking job\n"); // TODO
+
+    return return_value;
+  }
+
   dt_shortcut_t fsc = _sc;
   fsc.action = NULL;
   fsc.element  = 0;

--- a/src/gui/gtk.c
+++ b/src/gui/gtk.c
@@ -4188,6 +4188,7 @@ void dt_gui_cursor_set_busy()
     // since the main reason for calling this function is that we won't be running the Gtk main
     // loop for a while, ensure that the mouse cursor gets updated
     dt_gui_process_events();
+    gtk_grab_add(darktable.control->progress_system.proxy.module->widget);
   }
 }
 
@@ -4206,6 +4207,7 @@ void dt_gui_cursor_clear_busy()
       gdk_window_set_cursor(window, busy_prev_cursor);
       dt_gui_process_events();
       busy_prev_cursor = NULL;
+      gtk_grab_remove(darktable.control->progress_system.proxy.module->widget);
     }
   }
 }

--- a/src/libs/backgroundjobs.c
+++ b/src/libs/backgroundjobs.c
@@ -134,6 +134,10 @@ static gboolean _added_gui_thread(gpointer user_data)
   gtk_widget_show_all(params->instance_widget);
   gtk_widget_show(params->self_widget);
 
+  GdkCursor *cursor = gdk_cursor_new_for_display(gdk_display_get_default(), GDK_LEFT_PTR);
+  gdk_window_set_cursor(gtk_widget_get_window(params->instance_widget), cursor);
+  g_object_unref(cursor);
+
   free(params);
   return FALSE;
 }


### PR DESCRIPTION
This just shows busy cursor and blocks input. When mouse is over the jobs list (bottom left) it changes back to normal pointer to indicate you can press the cancel button(s).

To handle Esc I'd have to have access to the last started job (which should/must be the blocking one). Don't think that functionality exists.